### PR TITLE
refactor: receive a react element as props instead a imgurl array

### DIFF
--- a/src/components/molecules/Carousel/Carousel.test.tsx
+++ b/src/components/molecules/Carousel/Carousel.test.tsx
@@ -2,19 +2,21 @@ import { render } from "@testing-library/react";
 import Carousel from "./Carousel";
 
 describe("Carousel", () => {
-    const mockImgUrls = ["path/image_1.png", "path/image_2.png", "path/image_3.png"];
-    it("should render the same amount of elements within imgUrls array prop", () => {
-        const {container} = render(<Carousel imgUrls={mockImgUrls} autoplay/>);
+    const mockImgUrls = ["https://example.com/image1.jpg", "https://example.com/image2.jpg"];
+    const mockChildren = [
+        <img key={0} src="https://example.com/image1.jpg" alt="image1" />, 
+        <img key={1} src="https://example.com/image2.jpg" alt="image2" />
+    ];
 
-        container.querySelectorAll("img").forEach(element => {
+    it("should render the same amount of elements within children array prop", () => {
+        const {container} = render(<Carousel autoplay children={mockChildren}/>);
+        const imgElements = container.querySelectorAll("img");
+
+        imgElements.forEach(element => {
             const currentSrcAttribute: string = element.getAttribute("src") as string;
-            const currentAltAttribute: string = element.getAttribute("alt") as string;
-
             const includesSrcAttribute = mockImgUrls.includes(currentSrcAttribute);
-            const includesAltAttribute = mockImgUrls.includes(currentAltAttribute);
 
             expect(includesSrcAttribute).toBe(true)
-            expect(includesAltAttribute).toBe(true)
         });
     });
 });

--- a/src/components/molecules/Carousel/Carousel.tsx
+++ b/src/components/molecules/Carousel/Carousel.tsx
@@ -1,11 +1,14 @@
 import { Carousel as AntdCarousel } from "antd";
 import { CarouselPropTypes } from "./CarouselPropTypes";
+import { ReactElement } from "react";
 
-const Carousel = ({ imgUrls, autoplay }: CarouselPropTypes) => {
+const Carousel = ({ children, autoplay }: CarouselPropTypes) => {
     return(
         <AntdCarousel autoplay={autoplay}>
-            {imgUrls.map((imgUrl: string, index: number) => (
-                <img key={index} src={imgUrl} alt={imgUrl} />
+            {children.map((element: ReactElement, index: number) => (
+                <div key={index}>
+                    {element}
+                </div>
             ))}
         </AntdCarousel>
     )

--- a/src/components/molecules/Carousel/CarouselPropTypes.ts
+++ b/src/components/molecules/Carousel/CarouselPropTypes.ts
@@ -1,4 +1,6 @@
+import { ReactElement } from "react"
+
 export interface CarouselPropTypes {
-    imgUrls: string[]
+    children: ReactElement[]
     autoplay: boolean
 }


### PR DESCRIPTION
#### 🤔 Why?
- Receive a react element as props instead a imgurl array

#### 🛠 What I changed:
- src/components/molecules/Carousel/Carousel.test.tsx
- src/components/molecules/Carousel/Carousel.tsx
- src/components/molecules/Carousel/CarouselPropTypes.ts